### PR TITLE
One GPU RuntimeError Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Checkpoints will be saved to this folder.
 To check the loss values during training see ```log.txt```.
 By default the batch size is tunned to run on 8 GeForce RTX 3090 gpu (You can obtain the best performance after about 150 epochs). You can change the batch size in the train_params in ```.yaml``` file.
 
-:triangular_flag_on_post: Please use multiple GPUs to train your own model, if you use only one GPU, you would meet the inplace problem.
 
 Also, you can watch the training loss by running the following command:
 ```bash

--- a/run.py
+++ b/run.py
@@ -123,9 +123,9 @@ with torch.autograd.set_detect_anomaly(True):
             print(kp_detector)
         kp_detector= torch.nn.SyncBatchNorm.convert_sync_batchnorm(kp_detector)
 
-        kp_detector = DDP(kp_detector,device_ids=[opt.local_rank])
-        discriminator = DDP(discriminator,device_ids=[opt.local_rank])
-        generator = DDP(generator,device_ids=[opt.local_rank])
+        kp_detector = DDP(kp_detector,device_ids=[opt.local_rank],broadcast_buffers=False)
+        discriminator = DDP(discriminator,device_ids=[opt.local_rank],broadcast_buffers=False)
+        generator = DDP(generator,device_ids=[opt.local_rank],broadcast_buffers=False)
 
         dataset = FramesDataset(is_train=(opt.mode == 'train'), **config['dataset_params'])
         if not os.path.exists(log_dir):


### PR DESCRIPTION
Hello, thanks for your work!

I think I found a way to train on a single GPU. You need to set broadcast_buffers=False in the DDP call.
See more here: https://github.com/pytorch/pytorch/issues/22095#issuecomment-505099500